### PR TITLE
Changes made to recently generated code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    LockstepSdk (0.1.0)
+    LockstepSdk (2022.3.49.0)
       awrence
 
 GEM

--- a/lib/lockstep_sdk/clients/activities.rb
+++ b/lib/lockstep_sdk/clients/activities.rb
@@ -13,7 +13,7 @@
 # @version    2022.3
 # @link       https://github.com/Lockstep-Network/lockstep-sdk-ruby
 #
-
+require 'awrence'
 
 class ActivitiesClient
 
@@ -44,10 +44,10 @@ class ActivitiesClient
     # 
     # @param id [uuid] The unique Lockstep Platform ID number of the Activity to update
     # @param body [object] A list of changes to apply to this Activity
-    def update_activity(id:)
+    def update_activity(id:, body:)
         path = "/api/v1/Activities/#{id}"
         params = {}
-        @lockstepsdk.request(:patch, path, body, params)
+        @lockstepsdk.request(:patch, path, body.to_camelback_keys.to_json, params)
     end
 
     # Delete the Activity referred to by this unique identifier.
@@ -66,7 +66,7 @@ class ActivitiesClient
     # An Activity contains information about work being done on a specific accounting task. You can use Activities to track information about who has been assigned a specific task, the current status of the task, the name and description given for the particular task, the priority of the task, and any amounts collected, paid, or credited for the task.
     # 
     # @param body [ActivityModel] The Activities to create
-    def create_activities()
+    def create_activities(body:)
         path = "/api/v1/Activities"
         @lockstepsdk.request(:post, path, body, nil)
     end

--- a/lib/lockstep_sdk/clients/reports.rb
+++ b/lib/lockstep_sdk/clients/reports.rb
@@ -76,7 +76,7 @@ class ReportsClient
     # @param CurrencyCode [string] Currency aging buckets are converted to (all aging data returned without currency conversion if no currency is specified)
     # @param CurrencyProvider [string] Currency provider currency rates should be returned from to convert aging amounts to (default Lockstep currency provider used if no data provider specified)
     # @param Buckets [int32] Customized buckets used for aging calculations (default buckets [0,30,60,90,120,180] will be used if buckets not specified)
-    def invoice_aging_report(CompanyId:, Recalculate:, CurrencyCode:, CurrencyProvider:, Buckets:)
+    def invoice_aging_report(companyId:, recalculate:, currencyCode:, currencyProvider:, buckets:)
         path = "/api/v1/Reports/aging"
         params = {:CompanyId => CompanyId, :Recalculate => Recalculate, :CurrencyCode => CurrencyCode, :CurrencyProvider => CurrencyProvider, :Buckets => Buckets}
         @lockstepsdk.request(:get, path, nil, params)

--- a/lib/lockstep_sdk/lockstep_api.rb
+++ b/lib/lockstep_sdk/lockstep_api.rb
@@ -23,9 +23,7 @@ Dir.glob(project_root + '/clients/*') {|file| require file}
 
 module LockstepSdk
     class LockstepApi
-    
-        require 'awrence'
-    
+       
         # @return [String] The version number of this Lockstep API client
         attr_accessor :version
         # @return [String] The name or URL of the environment
@@ -86,7 +84,7 @@ module LockstepSdk
         # Construct a new Lockstep API client targeting the specified server.
         #
         # @param env [string] Either "sbx", "prd", or the URI of the server, ending in a slash (/)
-        def self.new(env)
+        def initialize(env)
             @version = "2022.3.49.0"
             @env = case env
                 when "sbx"
@@ -169,11 +167,8 @@ module LockstepSdk
                 end
             request["Accept"] = 'application/json'
             request["Content-Type"] = 'application/*+json'
-            
-            # Convert the body to json
-            if !body.nil?
-                request.body = body.to_camelback_keys.to_json
-            end
+
+            request.body = body
             
             # Which authentication are we using?
             if @api_key != nil 

--- a/lib/lockstep_sdk/models/activity_model.rb
+++ b/lib/lockstep_sdk/models/activity_model.rb
@@ -13,7 +13,7 @@
 # @version    2022.3
 # @link       https://github.com/Lockstep-Network/lockstep-sdk-ruby
 #
-
+require 'json'
 
 module LockstepSdk
 
@@ -22,7 +22,7 @@ module LockstepSdk
     # the current status of the task, the name and description given for the particular task,
     # the priority of the task, and any amounts collected, paid, or credited for the task.
     class ActivityModel
-
+        
         # Initialize the ActivityModel using the provided prototype
         def initialize(params = {})
             @activity_id = params.dig(:activity_id)
@@ -114,43 +114,43 @@ module LockstepSdk
         attr_accessor :custom_field_values
         # @return [ActivityXRefModel] All references attached to this applied activity. To retrieve this collection, specify `References` in the "Include" parameter for your query.
         attr_accessor :references
-    end
 
-    def as_json(options={})
-        {
-            'activityId' => @activity_id,
-            'groupKey' => @group_key,
-            'companyId' => @company_id,
-            'activityTypeCode' => @activity_type_code,
-            'activityName' => @activity_name,
-            'activityDescription' => @activity_description,
-            'activityStatus' => @activity_status,
-            'isOpen' => @is_open,
-            'priority' => @priority,
-            'userAssignedTo' => @user_assigned_to,
-            'dateAssigned' => @date_assigned,
-            'dateClosed' => @date_closed,
-            'snoozeUntilDate' => @snooze_until_date,
-            'created' => @created,
-            'createdUserId' => @created_user_id,
-            'modified' => @modified,
-            'modifiedUserId' => @modified_user_id,
-            'amountCollected' => @amount_collected,
-            'amountPaid' => @amount_paid,
-            'creditGiven' => @credit_given,
-            'isUnread' => @is_unread,
-            'isArchived' => @is_archived,
-            'company' => @company,
-            'userAssignedToName' => @user_assigned_to_name,
-            'attachments' => @attachments,
-            'notes' => @notes,
-            'customFieldDefinitions' => @custom_field_definitions,
-            'customFieldValues' => @custom_field_values,
-            'references' => @references,
-        }
-    end
+        def as_json(options={})
+            {
+                'activityId' => @activity_id,
+                'groupKey' => @group_key,
+                'companyId' => @company_id,
+                'activityTypeCode' => @activity_type_code,
+                'activityName' => @activity_name,
+                'activityDescription' => @activity_description,
+                'activityStatus' => @activity_status,
+                'isOpen' => @is_open,
+                'priority' => @priority,
+                'userAssignedTo' => @user_assigned_to,
+                'dateAssigned' => @date_assigned,
+                'dateClosed' => @date_closed,
+                'snoozeUntilDate' => @snooze_until_date,
+                'created' => @created,
+                'createdUserId' => @created_user_id,
+                'modified' => @modified,
+                'modifiedUserId' => @modified_user_id,
+                'amountCollected' => @amount_collected,
+                'amountPaid' => @amount_paid,
+                'creditGiven' => @credit_given,
+                'isUnread' => @is_unread,
+                'isArchived' => @is_archived,
+                'company' => @company,
+                'userAssignedToName' => @user_assigned_to_name,
+                'attachments' => @attachments,
+                'notes' => @notes,
+                'customFieldDefinitions' => @custom_field_definitions,
+                'customFieldValues' => @custom_field_values,
+                'references' => @references
+            } 
+        end
 
-    def to_json(*options)
-        as_json(*options).to_json(*options)
+        def to_json(*options)
+            "[#{as_json(*options).to_json(*options)}]"
+        end
     end
 end


### PR DESCRIPTION
Hey Ted! These are the changes made - 

In the main lockstep_api.rb file - 
   1. method's name should be initialize instead of self.new
   2. Removed awrence gem requirement and the body.nil? code. Added request.body
  
In every clients file - 
    1. Had to move the awrence gem back here and added body.to_camelback.to_json in update query. 
    2. Update and Create activity methods need  body: as an argument.
 
In reports.rb client - invoices_aging_report method, the args are in PascalCase. This is NOT allowed in ruby, so this would need special attention to make it snake_case (preferably). All arguments need to be in snake_case (preferably). Right now they are in camel case.

Client file names could be their respective class names in snake_case. Class names would be as is.

In each model file - 
   1. to_json and as_json should be inside the class.
   2. small update to to_json method.
   3. Add require 'json' at the top of each file.

The final issue we have is - 

I mentioned that some attributes were not required by the create API call. We discussed that if they were nil it might work.
The platform API did not accept this during my tests. 
So we would need to remove them from the generator. They should not be present as_json method. This would allow the user to create a model from the gem and call create API.

We would need a list of these attributes that are not accepted by the API. Would you be able to get them from your developers?
This is just a thought to solve the issue. Happy to get on a call if clarification required.

Note : A User could call the create API without the model but it would be a bigger hassle. 

Thank you!

PS : Please change my name to **Manish Narayan B S** as an author. :) It is wrong as of now. 