### PR TITLE
Update lockstepsdk.gemspec to new name

### DIFF
--- a/lockstepsdk.gemspec
+++ b/lockstepsdk.gemspec
@@ -1,7 +1,7 @@
 require_relative "lib/lockstep_sdk/version"
 
 Gem::Specification.new do |s|
-    s.name = 'LockstepSdk'
+    s.name = 'lockstep_sdk'
     s.version = '2022.4.32.0'
     s.date = '2022-01-28'
     s.summary = 'API Client to use the Lockstep Platform API'


### PR DESCRIPTION
Changing the gem name to conform to RubyGem.org best practices