### PR TITLE
Module names must be CONSTANT and begin with capitalization

### DIFF
--- a/lib/lockstep_sdk/lockstep_api.rb
+++ b/lib/lockstep_sdk/lockstep_api.rb
@@ -21,7 +21,7 @@ require 'socket'
 project_root = File.dirname(File.absolute_path(__FILE__))
 Dir.glob(project_root + '/clients/*') {|file| require file}
 
-module lockstep_sdk
+module Lockstep_sdk
     class LockstepApi
     
         ##


### PR DESCRIPTION
Quick fix for a minor typo introduced previously.